### PR TITLE
Fix devicemapper bug by installing aufs package and kernel module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* Install the aufs driver by default
+
 ## Version 1.2.0
 * distribute docker public key with formula so that we don't have to query ubuntu key server
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,5 @@
+To v1.3.0
+---------
+This version adds aufs support. Previously running docker containers will not be aware of this change and will need to be restarted manually.
+
+    service docker restart

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -7,6 +7,7 @@ docker-dependencies:
   pkg.installed:
     - pkgs:
       - ca-certificates
+      - linux-image-extra-{{ salt['grains.get']('kernelrelease') }}
 
 docker-pkg:
   pkg.installed:
@@ -14,6 +15,7 @@ docker-pkg:
     - require:
       - pkg: docker-dependencies
       - pkgrepo: docker_repo
+      - kmod: aufs
 
 docker-py:
   pip.installed:
@@ -33,3 +35,6 @@ docker:
   service.running:
     - require:
       - pkg: docker-pkg
+
+aufs:
+  kmod.present


### PR DESCRIPTION
Aufs support is not part of the main kernel modules but supplied as
as an additional module in the linux-kernel-extras package.
This change will enable aufs support out of the box by making sure
that the aufs module is installed and loaded into the running
kernel