### PR TITLE
Bump docker-py version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Version 1.3.x
+* Bump docker-py to version 1.2.2 this makes authenticating with private registries easier
+
 ## Version 1.3.0
 * Install the aufs driver by default
 

--- a/docker/map.jinja
+++ b/docker/map.jinja
@@ -2,7 +2,7 @@
     'Debian': {
         'pkg': 'lxc-docker',
         'pkg_version': '1.5.0',
-        'py_version': '1.0.0',
+        'py_version': '1.2.2',
     },
     'default': 'Debian',
 }, merge=salt['pillar.get']('docker',{})) %}


### PR DESCRIPTION
This makes it easier to authenticate with private registries.