### PR TITLE
Bump python-formula requirement to 1.6

### DIFF
--- a/formula-requirements.txt
+++ b/formula-requirements.txt
@@ -1,1 +1,1 @@
-ministryofjustice/python-formula==v1.1.5
+ministryofjustice/python-formula==v1.1.6


### PR DESCRIPTION
Bump python-formula requirement to 1.6 to accommodate the requests library issue.