### PR TITLE
Update extra kernel modules package name

### DIFF
--- a/docker/init.sls
+++ b/docker/init.sls
@@ -13,7 +13,7 @@ docker-dependencies:
 docker-kernel-dependencies:
   pkg.installed:
     - pkgs:
-      - linux-image-extra-{{ salt['grains.get']('kernelrelease') }}
+      - linux-modules-extra-{{ salt['grains.get']('kernelrelease') }}
     - unless: grep aufs /proc/filesystems
 
 docker-pkg:


### PR DESCRIPTION
The name has been changed from linux-image-extra to linux-modules-extra.